### PR TITLE
feat: add 14 new APIs and tidy up README table

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,101 +6,115 @@ Daftar API untuk kebutuhan Whatsapp bot
 
 ### LIST API
 
-| Nama API        | Developer | URL | Status  | Deskripsi | Auth |
-| --------------- |:---------:|:---:|:-------:|:----------|:------:|
-| Harz Rest API | [Harz](https://github.com/Har404-err) | [Link](https://api.harzrestapi.web.id) | `Aktif` | API Collection | `TIDAK` |
-| Fgsi RestAPIs | [FongsiDev](https://github.com/Fgsi-APIs) | [Link](https://fgsi1-restapi.hf.space) | `Aktif` | Fgsi RestAPIs | `TIDAK` |
-| TOXIC DEVIL API | [TOXIC-DEVIL](https://github.com/TOXIC-DEVIL) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | TOXIC DEVIL API - Free Rest API | `TIDAK` |
-| NirKYY API | [PurPur](https://whatsapp.com/channel/0029Vb3qLJRDuMRdjacRwe2T) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | Nirkyy Logic AI & collection | `TIDAK` |
-| XZN API | XZN | [link](https://xzn.wtf) | `Aktif` | API collection. | `APIKEY` |
-| ZEXXA API | [Kira-Master](https://github.com/Kira-Master) | [link](https://web-kira-master.cloud.okteto.net/) | `Aktif` | API collection. | `APIKEY` |
-| ZEXXA DEV | [ZexxaDevID](https://github.com/ZexxaDevID) | [link](http://myfirstexpress-1.xvdxsix.repl.co/) | `Aktif` | API collection. | TIDAK |
-| Kimzz API | Kimzz store | [link](https://api.kimzzoffc.me) | `Aktif` | API collection. | `APIKEY` |
-| Xcode API | [Riy](https://github.com/riycoders) | [Link](https://api.xcodeteam.xyz/) | `Aktif` | API collection. | `APIKEY` |
-| KYOUKA API | KyoukaDev | [link](https//github.com/Yuri-Neko)| [link](https://api.nekostore.my.id) | `Aktif` | API collection. | `APIKEY` |
-| Api Rull | Rull | [link](https://apiruulzz.my.id) | `Aktif` | API collection. | `APIKEY` |
-| Xteam | XTEAM | [Link](https://xteam.xyz) | `Aktif` | API collection. | `APIKEY` |
-| Danzz Api | Danzz Coding | [Link](https://danzzapi.xyz) | `Aktif` | API collection. | `APIKEY` |
-| Api Danzz | Danzz Coding | [Link](https://api-danzz.xyz) | `Aktif` | API collection. | `APIKEY` |
-| Antei codes| Antei codes Team | [Link](https://antei.codes/) | `Aktif` | API collection. | `APIKEY` |
-| Vhtear | veza | [Link](https://vhtear.com) | `Aktif` | API collection | `APIKEY` |
-| Caliph API | [CaliphDev](https://caliphdev.com) | [Link](https://api.caliph.biz.id) | `Aktif` | API collection | `APIKEY` |
-| Tiklydown API | [CaliphDev](https://caliphdev.com) | [Link](https://api.tiklydown.eu.org) | `Aktif` | TikTok API | `-` |
-| Fadzzz Api | FADZZZ PROJECT | [Link](https://api.fadzzzproject.my.id) | `Aktif` | API collection | `TIDAK` |
-| Ramlan Api | Ramlan ID | [Link](https://api-ramlan.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| Hardianto | Hardianto | [Link](https://hardianto.xyz) | `Aktif` | API collection | `APIKEY` |
-| Hadi Api | m hadi | [Link](https://hadi-api.herokuapp.com/api) | `Aktif` | API collection | Tidak |
-| Zenext Api | [zhwzein](https://github.com/zhwzein) | [Link](https://api.ouzen.xyz) | `Aktif` | API collection | `APIKEY` |
-| Zeks Api | vinz | [Link](https://zeks.me) | `Aktif` | API collection | `APIKEY` |
-| Rinz api | Rinz | [Link](https://rinz.my.id) | `Aktif` | API collection | `APIKEY` |
-| Starz Api | Bintang | [Link](http://st4rz.herokuapp.com/) | `Aktif` | API collection | Tidak |
-| Xcode | xcode7 | [Link](https://api-xcoders.xyz/) | `Aktif` | API collection | `APIKEY` |
-| ArugaZ API | ArugaZ | [Link](https://restfulapi.my.id/arugaz) | `Aktif` | Hasil Scrape Website - Lengkap | Tidak |
-| Neoxr | neoxr | [Link](https://api.neoxr.eu.org) | `Aktif` | API Collection | `APIKEY` |
-| Lolhuman Api| lolhuman | [Link](https://api.lolhuman.xyz) | `Aktif` | API collection | `APIKEY` |
-| Bx Hunter | ikyy | [Link](https://bx-hunter.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| Ostch | ibnusyawall | [Link](https://ostch.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| Tobz API | Toby | [Link](https://tobz-api.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| zeksais | zeksais | [Link](http://zekais-api.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| Dhnjing | Dehan | [Link](https://dhnjing.xyz) | `Aktif` | API collection | `APIKEY` |
-| Mfarels Api | mfarels | [Link](https://www.mfarels.id) | `Aktif` | Api collection | Tidak |
-| Kocakz | ArugaZ | [Link](https://kocakz.herokuapp.com) | `Aktif` | API collection | Tidak |
-| Revita Api | Revita | [Link](https://revita.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| nzcha Api | MRHRTZ | [Link](https://nzcha-apii.herokuapp.com) | `Aktif` | API collection | Tidak |
-| Jarx Api | Fajar | [Link](https://api.jarx.me) | `Aktif` | API collection | `APIKEY` |
-| Zeeone Api | zeeone | [Link](https://api-zeeoneofc.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| Nurutomo Api | Nurutomo | [Link](https://nurutomo.herokuapp.com) | `Aktif` | API collection | Tidak |
-| Erdwpe Api | Erdwpe | [Link](https://api.erdwpe.com) | `Aktif` | API collection | Tidak |
-| AdiOfficial API | M imam Adi | [Link](https://api.adiofficial.xyz) | `Aktif` | API collection. | `APIKEY` |
-| Melcanz Rest Api | [ariffb25](https://github.com/ariffb25) & [melcanz](https://github.com/melcanz) | [Link](https://melcanz.com) | `Aktif` | API collection | `APIKEY` |
-| Botstyle-api | [Benniismael](https://github.com/botstylee) | [Link](rest-beni.herokuapp.com/) | `Aktif` | API collection | `TIDAK` |
-| Onichan Api | [FERDIZ-afk](https://github.com/FERDIZ-afk) | [Link](https://oni-chan.my.id/) | `Aktif` | API collection | `APIKEY` |
-| Free Rest API | [SAMPINDO](https://sampindo.id) | [Link](https://freeapi.sampindo.id/) | `Aktif` | API Collection | Tidak |
-| Kotzyy API | [Kotzyy](https://github.com/Kotzyy) | [Link](https://api.justkotz.tech) | `Aktif` | API Collection | `APIKEY` |
-| Sanuwa API | [Sanuwa](https://github.com/sanuwaofficial) | [Link](https://sanuw-api.herokuapp.com/) | `Aktif` | API Collection | `APIKEY` |
-| Wibusoft Api |  [Arugaz](https://github.com/arugaz) | [Link](https://wibusoft.com) | `Aktif` | API collection | `TIDAK` |
-| Daphuy Api | dappa | [Link](https://dapuhy.xyz/) | `Aktif` | API collection | `APIKEY` |
-| Jojo Api | jojo | [Link](https://docs-jojo.herokuapp.com) | `Aktif` | API collection | `TIDAK` |
-| Zacros Api | Zacros Team | [Link](https://api.zacros.my.id/) | `Aktif` | API collection | `TIDAK` |
-| Cakrayp Api | [Cakra YP](https://github.com/cakrayp) | [Link](https://cloudsmart.my.id) | `Aktif` | API collection | `APIKEY` |
-| Restu Api | [MuhammadRestu999](https://github.com/MuhammadRestu999) | [Link](https://restu-restapi.herokuapp.com) | `Aktif` | RestApi full json | Tidak |
-| Wann ofc | wannofc | [Link](https://api-invibot.herokuapp.com) | `Aktif` | API collection | `APIKEY` |
-| YUU API | sidaniid | [Link](https://yuuapi.herokuapp.com) | `Aktif` | API Collection| `APIKEY` |
-| AquaBot API | [Sanuwa](https://github.com/sanuwaofficial) | [Link](https://api-aquabot.herokuapp.com/) | `Aktif` | API Collection | `APIKEY` |
-| violetics API | FazOne, Dehante,Zyy | [Link](https://violetics.pw) | `Aktif` | API Collection | `APIKEY` |
-| Yourclowns API | Rey | [Link](https://yourclown.eu.org) | `Aktif` | API Collection | `APIKEY` |
-| BetaBotz API | Lann | [Link](https://api.betabotz.eu.org) | `Aktif` | API Collection | `APIKEY` |
-| Fatih Arridho API | Fatih | [Link](https://fatiharridho.herokuapp.com) | `Aktif` | API Collection | `TIDAK` |
-| JUSTNPC API | Ditzzy | [Link](https://api.justnpc.ml) | `Aktif` | API Collection | `YA` |
-| Erza API | erza | [Link](https://erzaa.site) | `Tidak` | API Collection | `TIDAK` |
-| Rullz API | Rull | [link](https://apiruulzz.my.id) | `Aktif` | API Collection | `YA` |
-| API KYOUKA | FAJAR TKJ | [link](https://kyoukanime.my.id) | `Aktif` | API Collection | `YA` |
-| ZeroOne API | [Bintang1302](https://github.com/Bintang1302) | [Link](https://zerooneapi.eu.org) | `Aktif` | API Collection | `YA` |
-| Noid API | [xgorn](https://github.com/X-Gorn) | [Link](https://xgorn.is-a.dev/) | `Aktif` | API Collection | `APIKEY` |
-| MySiraj API | [Arizerr](https://github.com/Arizerr) | [Link](https://mysiraj.ddns.net/docs) | `Aktif` | Free Rest Api | `Tidak` |
-| Miftah API | [Miftah](https://github.com/miftah0908) | [Link](https://api.miftah.xyz) | `Aktif` | API Collection | `APIKEY` |
-| Xyro API | [Xyro](https://github.com/xyroinee) | [Link](https://api.xyroinee.xyz) | `Aktif` | API Collection | `APIKEY` |
-| VihangaYT API | [VihangYT](https://github.com/vihangayt0) | [Link](https://vihangayt.me) | `Aktif` | API Collection | `Tidak` |
-| Zaynn API | [Zaynn](https://github.com/zaynrck) | [Link](https://api.zaynn.my.id) | `Aktif` | API Collection | `APIKEY` |
-| Nimesh Offical API | [Nimesh Official](https://github.com/nimesh-official) | [Link](https://api.nimeshofficial.xyz) | `Aktif` | API Collection | `APIKEY` |
-| Zayn-C API | [NathanaeL](https://github.com/natgvlite) | [Link](https://api.zayn-c.my.id) | `Aktif` | Free Rest API | `Tidak` |
-| Nimesh Official API | [Nimesh Official](https://github.com/nimesh-official) | [Link](https://api.nimeshofficial.xyz) | `Aktif` | API Collection | `APIKEY` |
-| VELIXS R-API | [Ilsya](https://github.com/ilsyaa) | [Link](https://velixs.com/rapi) | `Aktif` | API Collection | `APIKEY` |
-| ZonerAPIs | [TegarPriyadi](https://github.com/TegarPriyadi) | [Link](https://api.zonerweb.biz.id/) | `Aktif` | API Collection | `APIKEY` |
-| VihangaYT API | [VihangYT](https://github.com/vihangayt0) | [Link](https://api.vihangayt.asia) | `Aktif` | API Collection | `Tidak` |
-| Miftah APIs | [Miftah](https://github.com/miftahganzz) | [Link](https://api.miftahganzz.my.id) | `Aktif` | API Collection | `APIKEY` |
-| ITzpire API | [Miftah](https://github.com/miftahganzz) | [Link](https://itzpire.site) | `Aktif` | API Collection | `Tidak` |
-| onesytex Api | [mr.one](https://github.com/onepunya) | [Link](https://onesytex.my.id) | `Aktif` | API Collection | `Tidak` |
-| MAHER API | [Maher Zubair](https://github.com/Maher-Zubair) | [Link](https://api.maher-zubair.tech) | `Aktif` | API Collection | `Tidak` |
-| SAMIR API | [SamirApi](https://github.com/samirxpikachuio) | [Link](https://samirxpikachu.onrender.com) | `Aktif` | API Collection | `Tidak` |
-| Mininxd API | [Mininxd](https://github.com/mininxd) | [Link](https://api.mininxd.my.id/) | `Aktif` | API Collection | `Tidak` |
-| AgatZ API | [AgatZ](https://github.com/agatdwi) | [Link](https://api.agatz.xyz) | `Aktif` | API Collection | `Tidak` |
-| Termai API | [TermaiApi](https://github.com/Rifza123) | [Link](https://xterm.tech) | `Aktif` | API Collection | `APIKEY` |
-| Chiwa RestAPI | [@akane_chiwa](https://github.com/aiprojectchiwa) | [Link](https://api.chiwa.my.id) | `Aktif` | 100% Free and PowerFull RestFullAPI | `TIDAK` |
-| Hitori API | [Hitori](https://github.com/bangdanzz) | [Link](https://my.hitori.pw) | `Aktif` | API Collection | `APIKEY` |
-| Dluxtzy API | [Wahyubotz78](https://github.com/Wahyubotz78) | [Link](https://api.dluxtzy.my.id) | `Aktif` | API Collection | `APIKEY` |
-| Genux API | [Genux Official](https://github.com/genux-official) | [Link](https://api.genux.me) | `Aktif` | API Collection | `APIKEY` |
-| onepunya api| [onepunya/mr.one.id](https://onepunya.github.io/siswanda-fox_onepunya-/) | [Link](https://onepunya.qzz.io) | `Aktif` | API Collection | `TIDAK` |
+| Nama API            | Developer                                                                       | URL                                               | Status  | Deskripsi                           | Auth     |
+| ------------------- | :-----------------------------------------------------------------------------: | :-----------------------------------------------: | :-----: | ----------------------------------- | :------: |
+| Harz Rest API       | [Harz](https://github.com/Har404-err)                                           | [Link](https://api.harzrestapi.web.id)            | `Aktif` | API Collection                      | `TIDAK`  |
+| Zenitsu API         | -                                                                               | [Link](https://api.zenitsu.web.id)                | `Aktif` | API Collection                      | `APIKEY` |
+| Zell API            | -                                                                               | [Link](https://zellapi.autos)                     | `Aktif` | API Collection                      | `APIKEY` |
+| Yupra API           | -                                                                               | [Link](https://api.yupra.my.id)                   | `Aktif` | API Collection                      | `APIKEY` |
+| Termai API          | -                                                                               | [Link](https://api.termai.cc)                     | `Aktif` | API Collection                      | `APIKEY` |
+| Siputzx API         | -                                                                               | [Link](https://api.siputzx.my.id)                 | `Aktif` | API Collection                      | `APIKEY` |
+| Ryzumi API          | -                                                                               | [Link](https://api.ryzumi.net)                    | `Aktif` | API Collection                      | `APIKEY` |
+| Nexray API          | -                                                                               | [Link](https://api.nexray.web.id)                 | `Aktif` | API Collection                      | `APIKEY` |
+| Kayzzidgf API       | -                                                                               | [Link](https://kayzzidgf.my.id)                   | `Aktif` | API Collection                      | `APIKEY` |
+| Faa API             | -                                                                               | [Link](https://api-faa.my.id)                     | `Aktif` | API Collection                      | `APIKEY` |
+| Cuki API            | -                                                                               | [Link](https://api.cuki.biz.id)                   | `Aktif` | API Collection                      | `APIKEY` |
+| Deline API          | -                                                                               | [Link](https://api.deline.web.id)                 | `Aktif` | API Collection                      | `APIKEY` |
+| Apocalypse API      | -                                                                               | [Link](https://api.apocalypse.web.id)             | `Aktif` | API Collection                      | `APIKEY` |
+| Denayrest API       | -                                                                               | [Link](https://api.denayrestapi.xyz)              | `Aktif` | API Collection                      | `APIKEY` |
+| Elrayyxml API       | -                                                                               | [Link](https://api.elrayyxml.web.id)              | `Aktif` | API Collection                      | `APIKEY` |
+| Fgsi RestAPIs       | [FongsiDev](https://github.com/Fgsi-APIs)                                       | [Link](https://fgsi1-restapi.hf.space)            | `Aktif` | Fgsi RestAPIs                       | `TIDAK`  |
+| TOXIC DEVIL API     | [TOXIC-DEVIL](https://github.com/TOXIC-DEVIL)                                   | [Link](https://toxicdevilapi.vercel.app/)         | `Aktif` | TOXIC DEVIL API - Free Rest API     | `TIDAK`  |
+| NirKYY API          | [PurPur](https://whatsapp.com/channel/0029Vb3qLJRDuMRdjacRwe2T)                 | [Link](https://toxicdevilapi.vercel.app/)         | `Aktif` | Nirkyy Logic AI & collection        | `TIDAK`  |
+| XZN API             | XZN                                                                             | [link](https://xzn.wtf)                           | `Aktif` | API collection.                     | `APIKEY` |
+| ZEXXA API           | [Kira-Master](https://github.com/Kira-Master)                                   | [link](https://web-kira-master.cloud.okteto.net/) | `Aktif` | API collection.                     | `APIKEY` |
+| ZEXXA DEV           | [ZexxaDevID](https://github.com/ZexxaDevID)                                     | [link](http://myfirstexpress-1.xvdxsix.repl.co/)  | `Aktif` | API collection.                     | `TIDAK`  |
+| Kimzz API           | Kimzz store                                                                     | [link](https://api.kimzzoffc.me)                  | `Aktif` | API collection.                     | `APIKEY` |
+| Xcode API           | [Riy](https://github.com/riycoders)                                             | [Link](https://api.xcodeteam.xyz/)                | `Aktif` | API collection.                     | `APIKEY` |
+| KYOUKA API          | KyoukaDev [link](https//github.com/Yuri-Neko)                                   | [link](https://api.nekostore.my.id)               | `Aktif` | API collection.                     | `APIKEY` |
+| Api Rull            | Rull                                                                            | [link](https://apiruulzz.my.id)                   | `Aktif` | API collection.                     | `APIKEY` |
+| Xteam               | XTEAM                                                                           | [Link](https://xteam.xyz)                         | `Aktif` | API collection.                     | `APIKEY` |
+| Danzz Api           | Danzz Coding                                                                    | [Link](https://danzzapi.xyz)                      | `Aktif` | API collection.                     | `APIKEY` |
+| Api Danzz           | Danzz Coding                                                                    | [Link](https://api-danzz.xyz)                     | `Aktif` | API collection.                     | `APIKEY` |
+| Antei codes         | Antei codes Team                                                                | [Link](https://antei.codes/)                      | `Aktif` | API collection.                     | `APIKEY` |
+| Vhtear              | veza                                                                            | [Link](https://vhtear.com)                        | `Aktif` | API collection                      | `APIKEY` |
+| Caliph API          | [CaliphDev](https://caliphdev.com)                                              | [Link](https://api.caliph.biz.id)                 | `Aktif` | API collection                      | `APIKEY` |
+| Tiklydown API       | [CaliphDev](https://caliphdev.com)                                              | [Link](https://api.tiklydown.eu.org)              | `Aktif` | TikTok API                          | `TIDAK`  |
+| Fadzzz Api          | FADZZZ PROJECT                                                                  | [Link](https://api.fadzzzproject.my.id)           | `Aktif` | API collection                      | `TIDAK`  |
+| Ramlan Api          | Ramlan ID                                                                       | [Link](https://api-ramlan.herokuapp.com)          | `Aktif` | API collection                      | `APIKEY` |
+| Hardianto           | Hardianto                                                                       | [Link](https://hardianto.xyz)                     | `Aktif` | API collection                      | `APIKEY` |
+| Hadi Api            | m hadi                                                                          | [Link](https://hadi-api.herokuapp.com/api)        | `Aktif` | API collection                      | `TIDAK`  |
+| Zenext Api          | [zhwzein](https://github.com/zhwzein)                                           | [Link](https://api.ouzen.xyz)                     | `Aktif` | API collection                      | `APIKEY` |
+| Zeks Api            | vinz                                                                            | [Link](https://zeks.me)                           | `Aktif` | API collection                      | `APIKEY` |
+| Rinz api            | Rinz                                                                            | [Link](https://rinz.my.id)                        | `Aktif` | API collection                      | `APIKEY` |
+| Starz Api           | Bintang                                                                         | [Link](http://st4rz.herokuapp.com/)               | `Aktif` | API collection                      | `TIDAK`  |
+| Xcode               | xcode7                                                                          | [Link](https://api-xcoders.xyz/)                  | `Aktif` | API collection                      | `APIKEY` |
+| ArugaZ API          | ArugaZ                                                                          | [Link](https://restfulapi.my.id/arugaz)           | `Aktif` | Hasil Scrape Website - Lengkap      | `TIDAK`  |
+| Neoxr               | neoxr                                                                           | [Link](https://api.neoxr.eu.org)                  | `Aktif` | API Collection                      | `APIKEY` |
+| Lolhuman Api        | lolhuman                                                                        | [Link](https://api.lolhuman.xyz)                  | `Aktif` | API collection                      | `APIKEY` |
+| Bx Hunter           | ikyy                                                                            | [Link](https://bx-hunter.herokuapp.com)           | `Aktif` | API collection                      | `APIKEY` |
+| Ostch               | ibnusyawall                                                                     | [Link](https://ostch.herokuapp.com)               | `Aktif` | API collection                      | `APIKEY` |
+| Tobz API            | Toby                                                                            | [Link](https://tobz-api.herokuapp.com)            | `Aktif` | API collection                      | `APIKEY` |
+| zeksais             | zeksais                                                                         | [Link](http://zekais-api.herokuapp.com)           | `Aktif` | API collection                      | `APIKEY` |
+| Dhnjing             | Dehan                                                                           | [Link](https://dhnjing.xyz)                       | `Aktif` | API collection                      | `APIKEY` |
+| Mfarels Api         | mfarels                                                                         | [Link](https://www.mfarels.id)                    | `Aktif` | Api collection                      | `TIDAK`  |
+| Kocakz              | ArugaZ                                                                          | [Link](https://kocakz.herokuapp.com)              | `Aktif` | API collection                      | `TIDAK`  |
+| Revita Api          | Revita                                                                          | [Link](https://revita.herokuapp.com)              | `Aktif` | API collection                      | `APIKEY` |
+| nzcha Api           | MRHRTZ                                                                          | [Link](https://nzcha-apii.herokuapp.com)          | `Aktif` | API collection                      | `TIDAK`  |
+| Jarx Api            | Fajar                                                                           | [Link](https://api.jarx.me)                       | `Aktif` | API collection                      | `APIKEY` |
+| Zeeone Api          | zeeone                                                                          | [Link](https://api-zeeoneofc.herokuapp.com)       | `Aktif` | API collection                      | `APIKEY` |
+| Nurutomo Api        | Nurutomo                                                                        | [Link](https://nurutomo.herokuapp.com)            | `Aktif` | API collection                      | `TIDAK`  |
+| Erdwpe Api          | Erdwpe                                                                          | [Link](https://api.erdwpe.com)                    | `Aktif` | API collection                      | `TIDAK`  |
+| AdiOfficial API     | M imam Adi                                                                      | [Link](https://api.adiofficial.xyz)               | `Aktif` | API collection.                     | `APIKEY` |
+| Melcanz Rest Api    | [ariffb25](https://github.com/ariffb25) & [melcanz](https://github.com/melcanz) | [Link](https://melcanz.com)                       | `Aktif` | API collection                      | `APIKEY` |
+| Botstyle-api        | [Benniismael](https://github.com/botstylee)                                     | [Link](rest-beni.herokuapp.com/)                  | `Aktif` | API collection                      | `TIDAK`  |
+| Onichan Api         | [FERDIZ-afk](https://github.com/FERDIZ-afk)                                     | [Link](https://oni-chan.my.id/)                   | `Aktif` | API collection                      | `APIKEY` |
+| Free Rest API       | [SAMPINDO](https://sampindo.id)                                                 | [Link](https://freeapi.sampindo.id/)              | `Aktif` | API Collection                      | `TIDAK`  |
+| Kotzyy API          | [Kotzyy](https://github.com/Kotzyy)                                             | [Link](https://api.justkotz.tech)                 | `Aktif` | API Collection                      | `APIKEY` |
+| Sanuwa API          | [Sanuwa](https://github.com/sanuwaofficial)                                     | [Link](https://sanuw-api.herokuapp.com/)          | `Aktif` | API Collection                      | `APIKEY` |
+| Wibusoft Api        | [Arugaz](https://github.com/arugaz)                                             | [Link](https://wibusoft.com)                      | `Aktif` | API collection                      | `TIDAK`  |
+| Daphuy Api          | dappa                                                                           | [Link](https://dapuhy.xyz/)                       | `Aktif` | API collection                      | `APIKEY` |
+| Jojo Api            | jojo                                                                            | [Link](https://docs-jojo.herokuapp.com)           | `Aktif` | API collection                      | `TIDAK`  |
+| Zacros Api          | Zacros Team                                                                     | [Link](https://api.zacros.my.id/)                 | `Aktif` | API collection                      | `TIDAK`  |
+| Cakrayp Api         | [Cakra YP](https://github.com/cakrayp)                                          | [Link](https://cloudsmart.my.id)                  | `Aktif` | API collection                      | `APIKEY` |
+| Restu Api           | [MuhammadRestu999](https://github.com/MuhammadRestu999)                         | [Link](https://restu-restapi.herokuapp.com)       | `Aktif` | RestApi full json                   | `TIDAK`  |
+| Wann ofc            | wannofc                                                                         | [Link](https://api-invibot.herokuapp.com)         | `Aktif` | API collection                      | `APIKEY` |
+| YUU API             | sidaniid                                                                        | [Link](https://yuuapi.herokuapp.com)              | `Aktif` | API Collection                      | `APIKEY` |
+| AquaBot API         | [Sanuwa](https://github.com/sanuwaofficial)                                     | [Link](https://api-aquabot.herokuapp.com/)        | `Aktif` | API Collection                      | `APIKEY` |
+| violetics API       | FazOne, Dehante,Zyy                                                             | [Link](https://violetics.pw)                      | `Aktif` | API Collection                      | `APIKEY` |
+| Yourclowns API      | Rey                                                                             | [Link](https://yourclown.eu.org)                  | `Aktif` | API Collection                      | `APIKEY` |
+| BetaBotz API        | Lann                                                                            | [Link](https://api.betabotz.eu.org)               | `Aktif` | API Collection                      | `APIKEY` |
+| Fatih Arridho API   | Fatih                                                                           | [Link](https://fatiharridho.herokuapp.com)        | `Aktif` | API Collection                      | `TIDAK`  |
+| JUSTNPC API         | Ditzzy                                                                          | [Link](https://api.justnpc.ml)                    | `Aktif` | API Collection                      | `YA`     |
+| Erza API            | erza                                                                            | [Link](https://erzaa.site)                        | `Tidak` | API Collection                      | `TIDAK`  |
+| Rullz API           | Rull                                                                            | [link](https://apiruulzz.my.id)                   | `Aktif` | API Collection                      | `YA`     |
+| API KYOUKA          | FAJAR TKJ                                                                       | [link](https://kyoukanime.my.id)                  | `Aktif` | API Collection                      | `YA`     |
+| ZeroOne API         | [Bintang1302](https://github.com/Bintang1302)                                   | [Link](https://zerooneapi.eu.org)                 | `Aktif` | API Collection                      | `YA`     |
+| Noid API            | [xgorn](https://github.com/X-Gorn)                                              | [Link](https://xgorn.is-a.dev/)                   | `Aktif` | API Collection                      | `APIKEY` |
+| MySiraj API         | [Arizerr](https://github.com/Arizerr)                                           | [Link](https://mysiraj.ddns.net/docs)             | `Aktif` | Free Rest Api                       | `TIDAK`  |
+| Miftah API          | [Miftah](https://github.com/miftah0908)                                         | [Link](https://api.miftah.xyz)                    | `Aktif` | API Collection                      | `APIKEY` |
+| Xyro API            | [Xyro](https://github.com/xyroinee)                                             | [Link](https://api.xyroinee.xyz)                  | `Aktif` | API Collection                      | `APIKEY` |
+| VihangaYT API       | [VihangYT](https://github.com/vihangayt0)                                       | [Link](https://vihangayt.me)                      | `Aktif` | API Collection                      | `TIDAK`  |
+| Zaynn API           | [Zaynn](https://github.com/zaynrck)                                             | [Link](https://api.zaynn.my.id)                   | `Aktif` | API Collection                      | `APIKEY` |
+| Nimesh Offical API  | [Nimesh Official](https://github.com/nimesh-official)                           | [Link](https://api.nimeshofficial.xyz)            | `Aktif` | API Collection                      | `APIKEY` |
+| Zayn-C API          | [NathanaeL](https://github.com/natgvlite)                                       | [Link](https://api.zayn-c.my.id)                  | `Aktif` | Free Rest API                       | `TIDAK`  |
+| Nimesh Official API | [Nimesh Official](https://github.com/nimesh-official)                           | [Link](https://api.nimeshofficial.xyz)            | `Aktif` | API Collection                      | `APIKEY` |
+| VELIXS R-API        | [Ilsya](https://github.com/ilsyaa)                                              | [Link](https://velixs.com/rapi)                   | `Aktif` | API Collection                      | `APIKEY` |
+| ZonerAPIs           | [TegarPriyadi](https://github.com/TegarPriyadi)                                 | [Link](https://api.zonerweb.biz.id/)              | `Aktif` | API Collection                      | `APIKEY` |
+| VihangaYT API       | [VihangYT](https://github.com/vihangayt0)                                       | [Link](https://api.vihangayt.asia)                | `Aktif` | API Collection                      | `TIDAK`  |
+| Miftah APIs         | [Miftah](https://github.com/miftahganzz)                                        | [Link](https://api.miftahganzz.my.id)             | `Aktif` | API Collection                      | `APIKEY` |
+| ITzpire API         | [Miftah](https://github.com/miftahganzz)                                        | [Link](https://itzpire.site)                      | `Aktif` | API Collection                      | `TIDAK`  |
+| onesytex Api        | [mr.one](https://github.com/onepunya)                                           | [Link](https://onesytex.my.id)                    | `Aktif` | API Collection                      | `TIDAK`  |
+| MAHER API           | [Maher Zubair](https://github.com/Maher-Zubair)                                 | [Link](https://api.maher-zubair.tech)             | `Aktif` | API Collection                      | `TIDAK`  |
+| SAMIR API           | [SamirApi](https://github.com/samirxpikachuio)                                  | [Link](https://samirxpikachu.onrender.com)        | `Aktif` | API Collection                      | `TIDAK`  |
+| Mininxd API         | [Mininxd](https://github.com/mininxd)                                           | [Link](https://api.mininxd.my.id/)                | `Aktif` | API Collection                      | `TIDAK`  |
+| AgatZ API           | [AgatZ](https://github.com/agatdwi)                                             | [Link](https://api.agatz.xyz)                     | `Aktif` | API Collection                      | `TIDAK`  |
+| Termai API          | [TermaiApi](https://github.com/Rifza123)                                        | [Link](https://xterm.tech)                        | `Aktif` | API Collection                      | `APIKEY` |
+| Chiwa RestAPI       | [@akane_chiwa](https://github.com/aiprojectchiwa)                               | [Link](https://api.chiwa.my.id)                   | `Aktif` | 100% Free and PowerFull RestFullAPI | `TIDAK`  |
+| Hitori API          | [Hitori](https://github.com/bangdanzz)                                          | [Link](https://my.hitori.pw)                      | `Aktif` | API Collection                      | `APIKEY` |
+| Dluxtzy API         | [Wahyubotz78](https://github.com/Wahyubotz78)                                   | [Link](https://api.dluxtzy.my.id)                 | `Aktif` | API Collection                      | `APIKEY` |
+| Genux API           | [Genux Official](https://github.com/genux-official)                             | [Link](https://api.genux.me)                      | `Aktif` | API Collection                      | `APIKEY` |
+| onepunya api        | [onepunya/mr.one.id](https://onepunya.github.io/siswanda-fox_onepunya-/)        | [Link](https://onepunya.qzz.io)                   | `Aktif` | API Collection                      | `TIDAK`  |
 
 
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Daftar API untuk kebutuhan Whatsapp bot
 
 | Nama API        | Developer | URL | Status  | Deskripsi | Auth |
 | --------------- |:---------:|:---:|:-------:|:----------|:------:|
+| Harz Rest API | [Harz](https://github.com/Har404-err) | [Link](https://api.harzrestapi.web.id) | `Aktif` | API Collection | `APIKEY` |
 | Fgsi RestAPIs | [FongsiDev](https://github.com/Fgsi-APIs) | [Link](https://fgsi1-restapi.hf.space) | `Aktif` | Fgsi RestAPIs | `TIDAK` |
 | TOXIC DEVIL API | [TOXIC-DEVIL](https://github.com/TOXIC-DEVIL) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | TOXIC DEVIL API - Free Rest API | `TIDAK` |
 | NirKYY API | [PurPur](https://whatsapp.com/channel/0029Vb3qLJRDuMRdjacRwe2T) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | Nirkyy Logic AI & collection | `TIDAK` |

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Daftar API untuk kebutuhan Whatsapp bot
 
 | Nama API        | Developer | URL | Status  | Deskripsi | Auth |
 | --------------- |:---------:|:---:|:-------:|:----------|:------:|
-| Harz Rest API | [Harz](https://github.com/Har404-err) | [Link](https://api.harzrestapi.web.id) | `Aktif` | API Collection | `APIKEY` |
+| Harz Rest API | [Harz](https://github.com/Har404-err) | [Link](https://api.harzrestapi.web.id) | `Aktif` | API Collection | `TIDAK` |
 | Fgsi RestAPIs | [FongsiDev](https://github.com/Fgsi-APIs) | [Link](https://fgsi1-restapi.hf.space) | `Aktif` | Fgsi RestAPIs | `TIDAK` |
 | TOXIC DEVIL API | [TOXIC-DEVIL](https://github.com/TOXIC-DEVIL) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | TOXIC DEVIL API - Free Rest API | `TIDAK` |
 | NirKYY API | [PurPur](https://whatsapp.com/channel/0029Vb3qLJRDuMRdjacRwe2T) | [Link](https://toxicdevilapi.vercel.app/) | `Aktif` | Nirkyy Logic AI & collection | `TIDAK` |

--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
 </head>
 <body>
-  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/Har404-err/API-COLLECTION">Here</a>.</noscript>
+  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/inirey/API-COLLECTION">Here</a>.</noscript>
   <div id="app">Loading...</div>
   <script>
     window.$docsify = {
       name: 'Daftar API untuk kebutuhan Whatsapp bot',
-      repo: 'https://github.com/Har404-err/API-COLLECTION',
+      repo: 'https://github.com/inirey/API-COLLECTION',
       search: ['/'],
       relativePath: true,
     }

--- a/index.html
+++ b/index.html
@@ -8,12 +8,12 @@
   <link rel="stylesheet" href="//unpkg.com/docsify/themes/vue.css">
 </head>
 <body>
-  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/inirey/API-COLLECTION">Here</a>.</noscript>
+  <noscript>This page requires JavaScript to work, please enable it or just read it on <a href="https://github.com/Har404-err/API-COLLECTION">Here</a>.</noscript>
   <div id="app">Loading...</div>
   <script>
     window.$docsify = {
       name: 'Daftar API untuk kebutuhan Whatsapp bot',
-      repo: 'https://github.com/inirey/API-COLLECTION',
+      repo: 'https://github.com/Har404-err/API-COLLECTION',
       search: ['/'],
       relativePath: true,
     }


### PR DESCRIPTION
- Added 14 new REST APIs: Zenitsu, Zell, Yupra, Termai, Siputzx, Ryzumi, Nexray,
     Kayzzidgf, Faa, Cuki, Deline, Apocalypse, Denayrest, and Elrayyxml.
   - Harmonized table structure for better readability.
   - Standardized 'Auth' and 'Status' column values.
   - Fixed broken table layouts in previous entries.